### PR TITLE
Add link to short definition of CC0

### DIFF
--- a/TERMS.md
+++ b/TERMS.md
@@ -1,7 +1,7 @@
 As a work of the United States Government, this package is in the
 public domain within the United States. Additionally, we waive
-copyright and related rights in the work worldwide through the CC0 1.0
-Universal public domain dedication.
+copyright and related rights in the work worldwide through the [CC0 1.0
+Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
 
 This work includes [DOCter from CFPB](https://github.com/cfpb/DOCter).  
 The following notice is amended to include 18F collaboration:


### PR DESCRIPTION
This update adds a link to the Public Domain Dedication description for CC0 the first time CC0 is cited.
